### PR TITLE
change default suggest port to 8000

### DIFF
--- a/app.js
+++ b/app.js
@@ -15,7 +15,7 @@
  * 
  *
  * The same command-line arguments are supported, e.g.:
- * `node app.js --silent --port=80 --prod`
+ * `node app.js --silent --port=8000 --prod`
  */
 
 // Ensure a "sails" can be located:


### PR DESCRIPTION
Hello,

better is to suggest port 8000, because port 80 requires root access.

Example: ```node app.js --silent --port=80 --prod``` would just hang up, and removing the --silence part will show ```warn: error raised: Error: listen EACCES```